### PR TITLE
fix: Decreased plugin processing time by 80%

### DIFF
--- a/.changeset/wild-items-argue.md
+++ b/.changeset/wild-items-argue.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-tailwind-purgecss': patch
+---
+
+fix: Decreased plugin processing time by 80%

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,8 +96,6 @@ export function purgeCss(purgeOptions?: PurgeOptions): Plugin {
 					...purgeOptions,
 					content: [join(viteConfig.root, '**/*.html'), ...(purgeOptions?.content ?? [])],
 					css: [{ raw: (asset.source as string).trim(), name: fileName }],
-					rejected: true,
-					rejectedCss: true,
 					safelist: {
 						...purgeOptions?.safelist,
 						standard,


### PR DESCRIPTION
Turns out that having `rejected` and `rejectedCss` enabled increased the purge time by 80% (in Skeleton, it reduced the doc site build from 55s -> 25s). These options were never meant to be on by default anyway, oops!