### PR TITLE
fix: SSR builds interfering with client builds

### DIFF
--- a/.changeset/fifty-jokes-bake.md
+++ b/.changeset/fifty-jokes-bake.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-tailwind-purgecss': patch
+---
+
+fix: SSR bundles no longer interfere with client bundles

--- a/.changeset/fifty-jokes-bake.md
+++ b/.changeset/fifty-jokes-bake.md
@@ -2,4 +2,4 @@
 'vite-plugin-tailwind-purgecss': patch
 ---
 
-fix: SSR bundles no longer interfere with client bundles
+fix: SSR builds no longer interfere with client builds

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 	"dependencies": {
 		"chalk": "^5.3.0",
 		"css-tree": "^2.3.1",
-		"estree-walker": "^3.0.3",
 		"fast-glob": "^3.3.2",
 		"purgecss": "^6.0.0",
 		"purgecss-from-html": "^6.0.0"
@@ -47,7 +46,6 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@types/css-tree": "^2.3.7",
-		"@types/estree": "^1.0.5",
 		"@types/node": "^18.11.18",
 		"prettier": "^2.8.1",
 		"tailwindcss": "^3.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   css-tree:
     specifier: ^2.3.1
     version: 2.3.1
-  estree-walker:
-    specifier: ^3.0.3
-    version: 3.0.3
   fast-glob:
     specifier: ^3.3.2
     version: 3.3.2
@@ -31,9 +28,6 @@ devDependencies:
   '@types/css-tree':
     specifier: ^2.3.7
     version: 2.3.7
-  '@types/estree':
-    specifier: ^1.0.5
-    version: 1.0.5
   '@types/node':
     specifier: ^18.11.18
     version: 18.11.18
@@ -710,6 +704,7 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
 
   /@types/is-ci@3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
@@ -1467,12 +1462,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     dev: true
-
-  /estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-    dependencies:
-      '@types/estree': 1.0.5
-    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import color from 'chalk';
 import path from 'node:path';
 import type { ResolvedConfig } from 'vite';
 
-export let log: ReturnType<typeof createLogger>;
+export type Logger = ReturnType<typeof createLogger>;
 
 export function createLogger(viteConfig: ResolvedConfig) {
 	const PREFIX = color.cyan('[vite-plugin-tailwind-purgecss]: ');
@@ -17,8 +17,6 @@ export function createLogger(viteConfig: ResolvedConfig) {
 			return colored;
 		},
 	};
-
-	log = logger;
 
 	return logger;
 }

--- a/src/purgecss-options.ts
+++ b/src/purgecss-options.ts
@@ -1,0 +1,23 @@
+export const getDefaultPurgeOptions = () => ({
+	css: [],
+	content: [],
+	extractors: [],
+	fontFace: false,
+	keyframes: false,
+	rejected: false,
+	rejectedCss: false,
+	sourceMap: false,
+	stdin: false,
+	stdout: false,
+	variables: false,
+	safelist: {
+		standard: [],
+		deep: [],
+		greedy: [],
+		variables: [],
+		keyframes: [],
+	},
+	blocklist: [],
+	skippedContentGlobs: [],
+	dynamicAttributes: [],
+});


### PR DESCRIPTION
closes #32 

This one was a doozy to figure out. 

The root of the issue was the blocklist being unintentionally shared across runs, causing the purge blocklist of the SSR build to share with the client build. The culprit was a global variable (my archnemesis) from PurgeCSS. 

While I was at it, I also took the liberty to simplify the extraction process to better match what tailwind would normally do, only extracting selectors from the source file rather than the compiled module.